### PR TITLE
initial commit of retrieve secrets using lambda

### DIFF
--- a/SSG-API-Testing-Application-v2/lambda/README.md
+++ b/SSG-API-Testing-Application-v2/lambda/README.md
@@ -1,0 +1,42 @@
+# Introduction
+This directory is still **WIP**
+
+It will contain POC of obtaining secrets from AWS Secrets Manager.
+
+This POC is meant to showcase how you can put your authentication secrets in AWS Secrets Manager and retrieve them to use when calling our APIs
+
+`lambda_function.py` contains the lambda function POC
+
+- Permissions given to the lambda function:
+    - AWSLambdaBasicExecutionRole (AWS managed)
+    - KmsDecrypt 
+    ```
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "VisualEditor0",
+                "Effect": "Allow",
+                "Action": "kms:Decrypt",
+                "Resource": "*"
+            }
+        ]
+    }
+    ```
+    - SecretsPolicy  
+    ```
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "VisualEditor0",
+                "Effect": "Allow",
+                "Action": [
+                    "secretsmanager:GetSecretValue"
+                ],
+                "Resource": "*"
+            }
+        ]
+    }
+    ```
+

--- a/SSG-API-Testing-Application-v2/lambda/lambda_function.py
+++ b/SSG-API-Testing-Application-v2/lambda/lambda_function.py
@@ -1,0 +1,37 @@
+# Use this code snippet in your app.
+# If you need more information about configurations
+# or implementing the sample code, visit the AWS docs:
+# https://aws.amazon.com/developer/language/python/
+
+import boto3
+from botocore.exceptions import ClientError
+
+def lambda_handler(event, context):
+    get_secret()
+
+def get_secret():
+
+    secret_name = "SampleApp/testing"
+    region_name = "ap-southeast-1"
+
+    # Create a Secrets Manager client
+    session = boto3.session.Session()
+    client = session.client(
+        service_name='secretsmanager',
+        region_name=region_name
+    )
+
+    try:
+        get_secret_value_response = client.get_secret_value(
+            SecretId=secret_name
+        )
+    except ClientError as e:
+        # For a list of exceptions thrown, see
+        # https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
+        raise e
+
+    secret = get_secret_value_response['SecretString']
+
+    # Your code goes here.
+    print(secret)
+    


### PR DESCRIPTION
There is a need to allow developers to have certificate and API key by default as there is turnaround time if they need to use their own.
Let's move to add a sample lambda function of how to use AWS secret manager while the full implementation is still being worked on.